### PR TITLE
Add package reference, list and removal commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",


### PR DESCRIPTION
Add dotnet sln, package and reference commands to enable listing, adding and removing dependencies

This enables the use of switching between a package to a a project reference making local development easier