### PR TITLE
fixes packages with only nohoist

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -255,7 +255,7 @@ export function list() {
 
 function expandWorkspaces(packageJsonPath: string) {
   const packageJson = JSON.parse(workspace.readFileSync(packageJsonPath).toString());
-  if (packageJson.workspaces) {
+  if (Array.isArray(packageJson.workspaces) || Array.isArray(packageJson.workspaces?.packages)) {
     const workspaces: WorkspacePackage[] = [];
     for (const workspace of packageJson.workspaces.packages ?? packageJson.workspaces) {
       const expanded = glob.sync(path.join(workspace, garnExecutable()), { cwd: path.dirname(packageJsonPath) });


### PR DESCRIPTION
prevents garn from assuming package has a package declaration when it only has a nohoist declaration in workspaces

allows for package.json with only nohoist in workspaces in accordance with https://classic.yarnpkg.com/blog/2018/02/15/nohoist/

``` package.json
...
"workspaces": {
  "nohoist": [...]
},
...
```
