### PR TITLE
fixes compilation root

### DIFF
--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -92,6 +92,7 @@ function compile() {
   parsed.options.module = ts.ModuleKind.CommonJS;
   parsed.options.jsx = ts.JsxEmit.React;
   parsed.options.incremental = true;
+  parsed.options.rootDir = backSlashToForwardSlash(rootPath);
   parsed.options.tsBuildInfoFile = backSlashToForwardSlash(path.join(buildCachePath, '.tsbuildinfo'));
   parsed.options.configFilePath = backSlashToForwardSlash(tsConfigPath);
 


### PR DESCRIPTION
prevents discrepancy between compilation root and root which is used when building files manifest which previously led to empty files declaration in simple buildsystems not including external search paths

To reproduce issue create package with single file buildsystem and check `.manifest.json` in `.buildcache`