### PR TITLE
Assume path of buildsystem if not passed as CLI arg

### DIFF
--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -5,11 +5,12 @@ const path = require('path');
 const minimist = require('minimist');
 
 const buildsystemPathArgName = 'buildsystem-path';
-if (!process.argv.find(v => v === '--' + buildsystemPathArgName)) {
+if (!process.argv.find(v => v.includes(`--${buildsystemPathArgName}`))) {
   const assumedBuildsystemPath = path.join(process.cwd(), 'buildsystem');
   if (!fs.existsSync(assumedBuildsystemPath)) {
     console.log('Error! No buildsystem folder exists at:', assumedBuildsystemPath);
-    console.log('You are most likely executing Garn from the incorrect folder. Your working directory should contain a folder called buildsystem that contains the Garn tasks.');
+    console.log('You are most likely executing Garn from the incorrect folder.');
+    console.log('Your working directory should contain a folder called buildsystem that contains the Garn tasks.');
     process.exit(1);
   }
   process.argv.push('--' + buildsystemPathArgName, assumedBuildsystemPath);

--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -4,9 +4,20 @@ const fs = require('fs');
 const path = require('path');
 const minimist = require('minimist');
 
+const buildsystemPathArgName = 'buildsystem-path';
+if (!process.argv.find(v => v === '--' + buildsystemPathArgName)) {
+  const assumedBuildsystemPath = path.join(process.cwd(), 'buildsystem');
+  if (!fs.existsSync(assumedBuildsystemPath)) {
+    console.log('Error! No buildsystem folder exists at:', assumedBuildsystemPath);
+    console.log('You are most likely executing Garn from the incorrect folder. Your working directory should contain a folder called buildsystem that contains the Garn tasks.');
+    process.exit(1);
+  }
+  process.argv.push('--' + buildsystemPathArgName, assumedBuildsystemPath);
+}
+
 const argv = minimist(process.argv.slice(2));
 
-const buildsystemPath = argv['buildsystem-path'];
+const buildsystemPath = argv[buildsystemPathArgName];
 const buildCache = '.buildcache';
 const buildCachePath = path.join(buildsystemPath, buildCache);
 const buildCacheManifestPath = path.join(buildCachePath, '.manifest.json');

--- a/src/index.ts
+++ b/src/index.ts
@@ -652,8 +652,9 @@ export async function writeMetaData(buildCachePath: string) {
   fs.writeFile(path.join(buildCachePath, garnMetaFile), JSON.stringify(json, null, 2), () => null);
 }
 
-export async function getMetaData(garnPath: string, isRetry = false): Promise<MetaData> {
-  const garnMetaFilePath = path.join(path.dirname(garnPath), 'buildsystem', '.buildcache', garnMetaFile);
+export async function getMetaData(workspacePath: string, isRetry = false): Promise<MetaData> {
+  const garnPath = path.join(workspacePath, 'node_modules', '.bin', garnExecutable());
+  const garnMetaFilePath = path.join(workspacePath, 'buildsystem', '.buildcache', garnMetaFile);
   if (fs.existsSync(garnMetaFilePath) && (isRetry || !('compile-buildsystem' in cliArgs.argv))) {
     try {
       return JSON.parse(fs.readFileSync(garnMetaFilePath).toString()) as MetaData;
@@ -667,8 +668,8 @@ export async function getMetaData(garnPath: string, isRetry = false): Promise<Me
     if ('compile-buildsystem' in cliArgs.argv) {
       args.push('--compile-buildsystem');
     }
-    await spawn(garnPath, args, { stdio: 'pipe', cwd: path.dirname(garnPath) });
-    return getMetaData(garnPath, true);
+    await spawn(garnPath, args, { stdio: 'pipe', cwd: workspacePath });
+    return getMetaData(workspacePath, true);
   } else {
     throw new Error(`Garn at '${garnPath}' does not seem to produce a meta file when executed`);
   }


### PR DESCRIPTION
This change makes it possible to run Garn completely as an npm executable without having a checked in `garn.cmd` file. Instead of Garn expecting `--buildsystem-path` to be passed as a CLI arg we now fallback to assuming that the current working directory has a folder called `buildsystem`. This is what people do in 99% of the cases anyway, execute Garn in the correct folder.

With this PR you can still have a checked in Garn executable, but it will also be possible to run `./node_modules/.bin/garn` directly.