### PR TITLE
Global install

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "^8.2.0",
     "glob": "^7.1.6",
     "inquirer": "^7.1.0",
+    "is-installed-globally": "^0.4.0",
     "minimist": "^1.2.5",
     "readline-sync": "^1.4.10",
     "rimraf": "^3.0.2",

--- a/src/run-in-parallel.ts
+++ b/src/run-in-parallel.ts
@@ -12,11 +12,7 @@ export type ParallelProgram = {
   prefix?: string;
 };
 
-export default async function runInParallel(
-  programs: ParallelProgram[],
-  isGarn: boolean = true,
-  maxParallelism = Infinity,
-) {
+export async function runInParallel(programs: ParallelProgram[], isGarn: boolean = true, maxParallelism = Infinity) {
   const batches: Array<Array<ParallelProgram>> = [];
   let i = 0;
   let currentBatch: ParallelProgram[] = [];

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -7,7 +7,7 @@ import * as git from './git';
 import * as cliArgs from './cli-args';
 import { Version } from './version';
 import * as log from './logging';
-import runInParallell from './run-in-parallell';
+import { runInParallel } from './run-in-parallel';
 import { spawn } from './exec';
 import { fromTag, isVersionTag } from './version';
 
@@ -103,7 +103,7 @@ export async function runTask(taskName: string, packageName?: string) {
   log.log('');
 
   const maxParallelism = (await cliArgs.flags.parallel.get()) ? Infinity : 1;
-  return await runInParallell(programs, true, maxParallelism);
+  return await runInParallel(programs, true, maxParallelism);
 }
 
 export async function runGarnPlugin() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,13 @@ glob@^7.1.3, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
+  integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
+  dependencies:
+    ini "2.0.0"
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -313,6 +320,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
+
 inquirer@^7.1.0:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
@@ -336,6 +348,19 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
+  dependencies:
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
+
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-object@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR checks if Garn is installed globally and will then execute `./node_modules/.bin/garn` instead of doing anything itself. This means that you can install Garn globally and run `garn` from CLI without needing to have `./node_modules/.bin` in your `PATH`.

This PR is based on top of #11 and the diff looks horrible because I had to indent all lines in the `garn-bin.js` file. But it's just the code above https://github.com/avensia-oss/garn/compare/garn-as-npm-executable...global-install?expand=1#diff-85172683fabc78444c6393e9e761ab81a24ef08c975b168c667eacc95a785905R26 that has changed.