### PR TITLE
Ensure we only have one git processing running in parallel

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from './exec';
+import { spawn } from './exec';
 import { projectPath } from './index';
 import * as log from './logging';
 import { fromTag, isVersionTag, Version } from './version';
@@ -154,18 +154,23 @@ export function pull(withRebase = true, cwd?: string) {
   return gitWithNetwork(args, cwd);
 }
 
-async function git(args: string[], cwd: string | undefined) {
-  const result = await spawn('git', args, { stdio: 'pipe', cwd: cwd ?? projectPath });
-  return result.stdout.trim();
-}
+// git on some Docker images such as alpine node behaves very odd when you run multiple git command
+// in parallel. This ensures that we're only running a single git command at a time.
+let currentCommand: Promise<unknown> = Promise.resolve();
 
-function gitSync(args: string[], cwd: string | undefined) {
-  const result = spawnSync('git', args, { stdio: 'pipe', cwd: cwd ?? projectPath });
-  return result.stdout.trim();
+async function git(args: string[], cwd: string | undefined) {
+  return (currentCommand = currentCommand.then(async () => {
+    const command = spawn('git', args, { stdio: 'pipe', cwd: cwd ?? projectPath });
+    const result = await command;
+    const stdout = result.stdout.trim();
+    return stdout;
+  }));
 }
 
 async function gitWithNetwork(args: string[], cwd: string | undefined) {
-  await spawn('git', args, { stdio: 'inherit', cwd });
+  return (currentCommand = currentCommand.then(async () => {
+    await spawn('git', args, { stdio: 'inherit', cwd });
+  }));
 }
 
 const separator = '?!!!!!?';
@@ -239,7 +244,7 @@ export async function logBetween(
     args.push(options.path);
   }
 
-  const rawCommitOutput = await gitSync(args, cwd);
+  const rawCommitOutput = await git(args, cwd);
 
   const rawCommits = rawCommitOutput
     .replace(/\r?\n/g, '') // Removes new line


### PR DESCRIPTION
This adds a mutex to ensure that we don't run multiple git commands in parallel. Running multiple git commands in parallel is fine on most machines and OSes, but I recently had really wierd issues when trying to do so with the Node Alpine docker image. Git would respond, but not with the correct data. Once I ensured that we only called `version.getCurrentVersion()` once at a time the issue went away.

So this PR makes sure that we're "safe by defaut". It does mean that if you query git a lot it's going to be slightly slower because we no longer do it in parallel but I don't think that matters as I don't know of any use case where we'd want to call git in parallel like that.