### PR TITLE
Check if whereis is installed before assuming that an executable is not in the PATH

### DIFF
--- a/src/exec.ts
+++ b/src/exec.ts
@@ -118,9 +118,7 @@ export function isInPath(command: string) {
     } else {
       const res = childProcess.spawnSync('whereis', [command]);
       if (res.error && (res.error as SpawnSyncError).code === 'ENOENT') {
-        // If `whereis` doesn't exist we assume that the command exists in the path. It might
-        // not but it's better to try and fail than to not try at all.
-        return true;
+       throw new Error(`Error trying to locate binary for "${command}". Make sure that 'whereis' is installed on your system.`);
       }
       if (res.status !== 0) {
         return false;


### PR DESCRIPTION
Another PR from my recent Node Alpine deep dive. Alpine doesn't come with `whereis` installed, so when trying to call `git` with `garn` you currently get an error that `git` is not in the `PATH`. Which it certainly is, but we interpret the failed call to `whereis` as `git` not being in the `PATH`. 

This PR changes so that if `whereis` isn't installed we assume that all executables is in the `PATH`. The worst scenario of this is slightly worse error messages, but at least we try calling the executable.