### PR TITLE
Interpret "on" as true for cli args

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -138,7 +138,7 @@ export async function getChildArgs() {
 
 function valueOf(valueString: string, type: FlagType): any {
   if (type === 'boolean') {
-    return (['y', 'yes', 't', 'true'].indexOf(valueString.toLowerCase()) !== -1) as unknown;
+    return (['y', 'yes', 't', 'true', 'on'].indexOf(valueString.toLowerCase()) !== -1) as unknown;
   } else if (type === 'number') {
     return Number(valueString.replace(',', '.').replace(/[^0-9\.]+/, '')) as unknown;
   }


### PR DESCRIPTION
This adds `on` as a valid value for `true` in cli args. My experience has been that writing `true/false` or `yes/no` feels less intuitive for most bool cli args and `on/off` feels more appropriate. This PR simply adds `on` as an additional allowed value to be interpreted as `true`. An example is an app I'm currently working on where we want to toggle server side rendering through a CLI arg and `--ssr on` feels more natural than `--ssr true`.