### PR TITLE
Convert garn-bin.js to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.7.0",
+  "version": "0.8.0-rc.0",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,8 @@
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",
   "license": "MIT",
-  "bin": "src/garn-bin.js",
+  "bin": "dist/garn-bin.js",
   "files": [
-    "src/garn-bin.js",
-    "src/garn.lua",
     "dist/**/*"
   ],
   "publishConfig": {
@@ -48,5 +46,6 @@
     "@types/string-similarity": "^3.0.0",
     "@types/through": "^0.0.30",
     "prettier": "^2.2.1"
-  }
+  },
+  "packageManager": "yarn@1.22.21"
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,16 @@
+// This contains code that is shared between garn-bin.ts and the rest of the code base.
+// This file is only allowed to export utilities and constants, and not contain any shared state.
+
+export const buildsystemPathArgName = 'buildsystem-path';
+export const asapArgName = 'asap';
+export const compileBuildsystemArgName = 'compile-buildsystem';
+export const childGarnArgName = 'child-garn';
+
+export function fromString(valueString: string, type: 'string' | 'number' | 'boolean'): any {
+  if (type === 'boolean') {
+    return (['y', 'yes', 't', 'true', 'on'].indexOf(valueString.toLowerCase()) !== -1) as unknown;
+  } else if (type === 'number') {
+    return Number(valueString.replace(',', '.').replace(/[^0-9\.]+/, '')) as unknown;
+  }
+  return valueString;
+}


### PR DESCRIPTION
This converts the file `garn-bin.js` to TypeScript and fixes a number of issues TypeScript told me about along the journey. It was a great ride.

Fixes #21