### PR TITLE
fix(changelog): remove brackets, add refs properly, and only show aut…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.5 (May 2, 2022)
+
+Fixes to the changelog to remove erroneous brackets and use consistent reference handling.
+Only show commit author and timestamp for individual commits.
+
 ## 0.4.1 (April 11, 2022)
 
 This version _shouldn't_ contain any breaking changes, but it does include some new features and quality-of-life stuff. The main gist of these changes are to reduce the need to have garn support scripts in your project, ie. `garn.cmd`/`./garn`, and to remove the need to add `./node_modules/.bin/` to your path.
@@ -15,7 +20,7 @@ This version _shouldn't_ contain any breaking changes, but it does include some 
 
 ## 0.4.0 [DEPRICATED]
 
-- Don't use. Missing vital files. 
+- Don't use. Missing vital files.
 
 ## 0.3.0 (January 20, 2022)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/src/change-log.ts
+++ b/src/change-log.ts
@@ -17,9 +17,8 @@ const formatters: { [key: string]: ChangeLogFormatter } = {
       const lines: string[] = [];
 
       if (commit.isMerge) {
-        const refs = commit.references && commit.references != '' ? '- ${commit.references}' : '';
         lines.push(
-          `- [(#${commit.merge?.pullNumber} - ${commit.body})](${repoUrl}/pull/${commit.merge?.pullNumber}) ${refs}`,
+          `- [#${commit.merge?.pullNumber} - ${commit.body}](${repoUrl}/pull/${commit.merge?.pullNumber}) ${commit.references}`,
         );
         lines.push(`   `);
       } else {
@@ -29,10 +28,11 @@ const formatters: { [key: string]: ChangeLogFormatter } = {
           lines.push(`  ${commit.body}`);
           lines.push(`   `);
         }
+
+        lines.push(`  <sup>Date: ${commit.date}, author: [${commit.author}](${commit.email})</sup>  `);
+        lines.push(`   `);
       }
 
-      lines.push(`  <sup>Date: ${commit.date}, author: [${commit.author}](${commit.email})</sup>  `);
-      lines.push(`   `);
       return lines;
     },
   },


### PR DESCRIPTION
…hors on commits

Some tidying to remove noise and errors around formatting of pull request highlights elements.

Where we wrapped pull requests links with so

- #175 - Commercetools: Shipping fee in order-edit
became
 - (#175 - Commercetools: Shipping fee in order-edit)
and if there was some case where  a commit reference was causing it to pass the check but not output anything
so this resulted in a trailing '-'
- (#175 - Commercetools: Shipping fee in order-edit) -

we also appended authors under each pull but in the existing change log we dont do this and its tidier
![image](https://user-images.githubusercontent.com/1974225/171136925-d0d1f029-1071-4fec-8c23-dcf43be0ecbd.png)

