### PR TITLE
Fixes

### DIFF
--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -222,7 +222,7 @@ function compileIfNeededAndRun(argv, rootPath, buildsystemPath, buildCache, buil
     });
     for (const info of packages) {
       const potentialPackageJson = path.join(allPackagesPath, info.name, 'package.json');
-      if (info.isDirectory && fs.existsSync(potentialPackageJson)) {
+      if (info.isDirectory() && fs.existsSync(potentialPackageJson)) {
         fs.copyFileSync(potentialPackageJson, path.join(packagesPath, info.name, 'package.json'));
       }
     }

--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -260,6 +260,8 @@ function compileIfNeededAndRun(argv, rootPath, buildsystemPath, buildCache, buil
       console.error(e);
       process.exit(1);
     });
+  }).catch(e => {
+    console.error('error writing garn metadata', e);
   });
 }
 

--- a/src/run-in-parallel.ts
+++ b/src/run-in-parallel.ts
@@ -10,6 +10,7 @@ export type ParallelProgram = {
   program: string;
   args: string[];
   prefix?: string;
+  cwd?: string;
 };
 
 export async function runInParallel(programs: ParallelProgram[], isGarn: boolean = true, maxParallelism = Infinity) {
@@ -34,7 +35,7 @@ export async function runInParallel(programs: ParallelProgram[], isGarn: boolean
   return maxParallelism === Infinity ? results[0] : results;
 }
 
-function executePrograms(programs: { program: string; args: string[]; prefix?: string }[], isGarn: boolean = true) {
+function executePrograms(programs: ParallelProgram[], isGarn: boolean = true) {
   let anyStreamIsOutputting = false;
   let unpauseStreams: Array<() => void> = [];
   return Promise.all(
@@ -55,7 +56,7 @@ function executePrograms(programs: { program: string; args: string[]; prefix?: s
         }
 
         log.verbose(`Spawning '${program.program}${args.length === 0 ? '' : ' '}${args.join(' ')}'`);
-        const command = spawn(program.program, args, { stdio });
+        const command = spawn(program.program, args, { stdio, ...(program.cwd ? { cwd: program.cwd } : {}) });
 
         const outThrough = through(
           function (this: any, data) {


### PR DESCRIPTION
If we feel we don't want to require a buildsystem directory in a workspace i can work around it by implementing package.json workspaces exclude patten (either with ! in worksapces or as a new property of other tooling reading workspaces end up acting up with !
