### PR TITLE
Base prerelease

### DIFF
--- a/src/release.ts
+++ b/src/release.ts
@@ -66,7 +66,7 @@ export enum ReleaseType {
   BasePrerelease,
 }
 
-export async function tagBasePrerelease(prereleaseTag = defaultPrereleaseTag, releaseBranch = defaultReleaseBranch) {
+export async function tagBasePrerelease(prereleaseTag: string, releaseBranch = defaultReleaseBranch) {
   return await createReleaseTag(ReleaseType.BasePrerelease, releaseBranch, prereleaseTag, undefined);
 }
 
@@ -88,7 +88,7 @@ export async function tagPackagesBasePrerelease(
 
 export async function tagPackagesPrerelease(
   packages: string[],
-  prereleaseTag = defaultPrereleaseTag,
+  prereleaseTag: string,
   releaseBranch = defaultReleaseBranch,
 ) {
   return await createReleaseTag(ReleaseType.ReleaseCandidate, releaseBranch, prereleaseTag, packages);

--- a/src/version.ts
+++ b/src/version.ts
@@ -144,7 +144,7 @@ export async function fromTag(gitTag: string, includeSha: boolean = true): Promi
   const packageName = gitTagRegex.exec(gitTag)?.groups?.name;
   const version = gitTagRegex.exec(gitTag)?.groups?.versionCore!;
 
-  const prereleaseParts = gitTag.split(/-([a-zA-Z]+)\.([0-9]+)$/);
+  const prereleaseParts = gitTag.split(/-([a-zA-Z0-9\.]+)\.([0-9]+)$/);
   const prerelease: Prerelease | undefined =
     prereleaseParts.length === 4 ? { tag: prereleaseParts[1], number: Number(prereleaseParts[2]) } : undefined;
 


### PR DESCRIPTION
A common problem we've been having is that there are RCs created just so ppl can try out their changes in their projects. When several projects create their own RCs (that should've been prereleases and not RCs) you either have package@nextversion-prereleasename.iteration where you either have vastly different content in the different prereleases targeting a next version where it's likely none of the changes will make it in to that version.

To solve this we're introducing base prereleases or possibly postreleasese where we instead create package@based-off-of-version-prereleasename.iteration

In addition to this this PR also allows prerelease names to contain period.

This PR is on top of #24