### PR TITLE
Require tsconfig.json for it to be deemed a workspace

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -280,7 +280,7 @@ function expandWorkspaces(packageJsonPath: string) {
               garnPath: path.join(path.dirname(packageJsonPath), e),
             };
           })
-          .filter(entry => fs.existsSync(path.join(entry.workspacePath, 'buildsystem'))),
+          .filter(entry => fs.existsSync(path.join(entry.workspacePath, 'buildsystem', 'tsconfig.json'))),
       );
     }
 


### PR DESCRIPTION
Workspaces that only exist on a branch will leave artifacts when switching branch. Garn's buildcache will still be there post branch switch because it's not tracked by git. This will cause garn to think that a workspace is available even though it only contains untracked files and folders. 

This change makes it so that a workspace needs to have a tsconf.json available, filtering out the "empty" workspaces. 
That tsconfig.json is a good filter candidate since it's already required by garn when compiling each workspace's buildsystem. 