### PR TITLE
chore: bump support for yarn v1 and v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.6.0-rc.3",
+  "version": "0.6.0-rc.4",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.5.4",
+  "version": "0.6.0-rc.2",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -77,7 +77,7 @@ if (isInstalledGlobally) {
  * @returns string
  */
 function getYarnChecksumFilePath(yarnLockPath) {
-  const yarnLockChecksumPath = path.join(path.dirname(yarnLockPath), '.yarn.checksum');
+  const yarnLockChecksumPath = path.join(path.dirname(yarnLockPath), 'tools', '.yarn.checksum');
   return yarnLockChecksumPath;
 }
 

--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -149,8 +149,7 @@ function restoreNpmPackages(
       stdio: 'inherit',
     });
     yarn.on('exit', exitCode => {
-      const ec = exitCode || 1;
-      if (ec < 1) {
+      if (exitCode < 1) {
         cpSync(yarnLockPath, copiedYarnLockPath);
 
         const yarnLockChecksumPath = getYarnChecksumFilePath(yarnLockPath);
@@ -159,7 +158,7 @@ function restoreNpmPackages(
 
         restartGarn();
       } else {
-        process.exit(ec);
+        process.exit(exitCode);
       }
     });
   } else if (restorePackagesWith === 'npm') {

--- a/src/garn-bin.js
+++ b/src/garn-bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
 const fs = require('fs');
+const crypto = require('crypto');
 const os = require('os');
 const childProcess = require('child_process');
 const path = require('path');
@@ -55,12 +56,7 @@ if (isInstalledGlobally) {
   const copiedYarnLockPath = path.join(buildCachePath, '.yarn.lock');
   const copiedPackageLockJsonPath = path.join(buildCachePath, '.package-lock.json');
 
-  const shouldRestore = shouldRestoreNpmPackages(
-    packageLockJsonPath,
-    yarnLockPath,
-    copiedPackageLockJsonPath,
-    copiedYarnLockPath,
-  );
+  const shouldRestore = shouldRestoreNpmPackages(packageLockJsonPath, yarnLockPath, copiedPackageLockJsonPath);
   if (shouldRestore === false) {
     compileIfNeededAndRun(argv, rootPath, buildsystemPath, buildCache, buildCachePath, buildCacheManifestPath);
   } else {
@@ -74,6 +70,41 @@ if (isInstalledGlobally) {
       copiedYarnLockPath,
     );
   }
+}
+
+/**
+ * @param {string} yarnLockPath
+ * @returns string
+ */
+function getYarnChecksumFilePath(yarnLockPath) {
+  const yarnLockChecksumPath = path.join(path.dirname(yarnLockPath), '.yarn.checksum');
+  return yarnLockChecksumPath;
+}
+
+/**
+ * @param {string} yarnLockPath
+ */
+function getYarnLockHash(yarnLockPath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(yarnLockPath)).digest('hex');
+}
+
+/**
+ * @param {string} yarnLockPath
+ * @returns boolean
+ */
+function getShouldUpdateLockFile(yarnLockPath) {
+  const yarnLockChecksumPath = getYarnChecksumFilePath(yarnLockPath);
+  const lockFileHash = getYarnLockHash(yarnLockPath);
+  let shouldUpdateLockFile = true;
+
+  if (!fs.existsSync(yarnLockChecksumPath)) {
+    fs.writeFileSync(yarnLockChecksumPath, lockFileHash);
+  } else {
+    const currentCachedHash = fs.readFileSync(yarnLockChecksumPath).toString();
+    shouldUpdateLockFile = lockFileHash !== currentCachedHash;
+  }
+
+  return shouldUpdateLockFile;
 }
 
 /**
@@ -112,16 +143,23 @@ function restoreNpmPackages(
     if (!fs.existsSync(yarnPath)) {
       yarnPath = 'yarn' + execExt;
     }
+
     const yarn = childProcess.spawn(yarnPath, [], {
       cwd: process.cwd(),
       stdio: 'inherit',
     });
     yarn.on('exit', exitCode => {
-      if (exitCode < 1) {
+      const ec = exitCode || 1;
+      if (ec < 1) {
         cpSync(yarnLockPath, copiedYarnLockPath);
+
+        const yarnLockChecksumPath = getYarnChecksumFilePath(yarnLockPath);
+        const lockFileHash = getYarnLockHash(yarnLockPath);
+        fs.writeFileSync(yarnLockChecksumPath, lockFileHash);
+
         restartGarn();
       } else {
-        process.exit(exitCode);
+        process.exit(ec);
       }
     });
   } else if (restorePackagesWith === 'npm') {
@@ -159,21 +197,16 @@ function cpSync(sourcePath, destinationPath) {
  * @param {string} packageLockJsonPath
  * @param {string} yarnLockPath
  * @param {string} copiedPackageLockJsonPath
- * @param {string} copiedYarnLockPath
  */
-function shouldRestoreNpmPackages(packageLockJsonPath, yarnLockPath, copiedPackageLockJsonPath, copiedYarnLockPath) {
+function shouldRestoreNpmPackages(packageLockJsonPath, yarnLockPath, copiedPackageLockJsonPath) {
   if (fs.existsSync(yarnLockPath)) {
-    if (!fs.existsSync(copiedYarnLockPath)) {
+    const hasNodeModulesFolder = fs.existsSync(path.join(yarnLockPath, '..', 'node_modules'));
+    let shouldUpdateLockFile = getShouldUpdateLockFile(yarnLockPath);
+
+    if (!hasNodeModulesFolder || shouldUpdateLockFile) {
       return 'yarn';
     } else {
-      const yarnLockStats = fs.statSync(yarnLockPath);
-      const copiedYarnLockStats = fs.statSync(copiedYarnLockPath);
-
-      if (yarnLockStats.mtime.getTime() !== copiedYarnLockStats.mtime.getTime()) {
-        return 'yarn';
-      } else {
-        return false;
-      }
+      return false;
     }
   } else if (fs.existsSync(packageLockJsonPath)) {
     if (!fs.existsSync(copiedPackageLockJsonPath)) {
@@ -255,14 +288,16 @@ function compileIfNeededAndRun(argv, rootPath, buildsystemPath, buildCache, buil
   } else {
     promise = garn.writeMetaDataIfNotExists(buildCachePath);
   }
-  promise.then(() => {
-    return garn.run().catch(e => {
-      console.error(e);
-      process.exit(1);
+  promise
+    .then(() => {
+      return garn.run().catch(e => {
+        console.error(e);
+        process.exit(1);
+      });
+    })
+    .catch(e => {
+      console.error('error writing garn metadata', e);
     });
-  }).catch(e => {
-    console.error('error writing garn metadata', e);
-  });
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -673,14 +673,8 @@ export async function getMetaData(pkg: WorkspacePackage, isRetry = false): Promi
       args.push('--compile-buildsystem');
     }
 
-    return await new Promise(async resolve => {
-      spawn(garnPath, args, { stdio: 'pipe', cwd: pkg.workspacePath }).finally(() => {
-        // Push the resolve one tick.
-        setTimeout(() => {
-          resolve(getMetaData(pkg, true));
-        });
-      });
-    });
+    await spawn(garnPath, args, { stdio: 'pipe', cwd: pkg.workspacePath });
+    return getMetaData(pkg, true);
   } else {
     throw new Error(`Garn at '${garnPath}' does not seem to produce a meta file when executed`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import * as prompt from './prompt';
 import defaultTask from './default-task';
 import * as workspace from './workspace';
 import * as chalk from 'chalk';
+import { WorkspacePackage } from './workspace';
 
 type Workpace = typeof workspace;
 type ExternalWorkspace = Omit<Workpace, 'runGarnPlugin' | 'getGarnPluginMetaData'>;
@@ -654,9 +655,10 @@ export async function writeMetaData(buildCachePath: string) {
   fs.writeFile(path.join(buildCachePath, garnMetaFile), JSON.stringify(json, null, 2), () => null);
 }
 
-export async function getMetaData(workspacePath: string, isRetry = false): Promise<MetaData> {
-  const garnPath = path.join(workspacePath, 'node_modules', '.bin', garnExecutable());
-  const garnMetaFilePath = path.join(workspacePath, 'buildsystem', '.buildcache', garnMetaFile);
+export async function getMetaData(pkg: WorkspacePackage, isRetry = false): Promise<MetaData> {
+  const garnPath = pkg.garnPath;
+  const garnMetaFilePath = path.join(pkg.workspacePath, 'buildsystem', '.buildcache', garnMetaFile);
+
   if (fs.existsSync(garnMetaFilePath) && (isRetry || !('compile-buildsystem' in cliArgs.argv))) {
     try {
       return JSON.parse(fs.readFileSync(garnMetaFilePath).toString()) as MetaData;
@@ -670,8 +672,15 @@ export async function getMetaData(workspacePath: string, isRetry = false): Promi
     if ('compile-buildsystem' in cliArgs.argv) {
       args.push('--compile-buildsystem');
     }
-    await spawn(garnPath, args, { stdio: 'pipe', cwd: workspacePath });
-    return getMetaData(workspacePath, true);
+
+    return await new Promise(async resolve => {
+      spawn(garnPath, args, { stdio: 'pipe', cwd: pkg.workspacePath }).finally(() => {
+        // Push the resolve one tick.
+        setTimeout(() => {
+          resolve(getMetaData(pkg, true));
+        });
+      });
+    });
   } else {
     throw new Error(`Garn at '${garnPath}' does not seem to produce a meta file when executed`);
   }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -258,6 +258,7 @@ export function list() {
 
 function expandWorkspaces(packageJsonPath: string) {
   const packageJson = JSON.parse(workspace.readFileSync(packageJsonPath).toString());
+  const projectRoot = path.dirname(packageJsonPath);
 
   if (Array.isArray(packageJson.workspaces) || Array.isArray(packageJson.workspaces?.packages)) {
     const workspaces: WorkspacePackage[] = [];
@@ -265,7 +266,7 @@ function expandWorkspaces(packageJsonPath: string) {
     for (const workspace of packageJson.workspaces.packages ?? packageJson.workspaces) {
       // Find each workspace that have a dependency on garn.
       const expanded = glob.sync(path.join(workspace, 'buildsystem', 'tsconfig.json'), {
-        cwd: path.dirname(packageJsonPath),
+        cwd: projectRoot,
       });
 
       workspaces.push(
@@ -275,8 +276,8 @@ function expandWorkspaces(packageJsonPath: string) {
             const relativeWorkspacePath = path.join(e, '..', '..'); // Ugly af
             return {
               name: path.basename(relativeWorkspacePath),
-              workspacePath: path.join(path.dirname(packageJsonPath), relativeWorkspacePath),
-              garnPath: path.join(packageJsonPath, '..', 'node_modules', '.bin', garnExecutable()),
+              workspacePath: path.join(projectRoot, relativeWorkspacePath),
+              garnPath: path.join(projectRoot, 'node_modules', '.bin', garnExecutable()),
             };
           })
           .filter(entry => fs.existsSync(path.join(entry.workspacePath, 'buildsystem', 'tsconfig.json'))),


### PR DESCRIPTION
This will enable yarn v4 support with module hoisting. It is backward compatible with yarn v1.