### PR TITLE
fix: handle environment variables for *nix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",


### PR DESCRIPTION
Today we convert environment variables into cli argument. But if we take an example;

```typescript
const flags = {
  fooBar: cliArgs.registerFlag<string>('foo-bar 'string'),
};
```

This will be usable by either setting `foo-bar=baz` on the machine that runs garn or passing it in as an argument `garn --foo-bar baz`. However hypen (`-`) is not valid for shells like bash or sh. The accepted characters range is `[a-zA-Z_]{1,}[a-zA-Z0-9_]*`. 

```typescript
const flags = {
  fooBar: cliArgs.registerFlag<string>('foo_bar 'string'),
};
```

There is hacky ways to get env vars in using tricks like `env 'foo-bar=baz' && echo `env` | grep foo-bar`. But it's better to be 100% POSIX compatible so we do not have to do inconvenient things for *nix environments.
