### PR TITLE
fix: yarn bin exec with yarn v2+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.10.0",
+  "version": "0.10.0-rc.0",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.10.0-rc.0",
+  "version": "0.10.0-rc.1",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",
@@ -33,8 +33,7 @@
     "readline-sync": "^1.4.10",
     "rimraf": "^3.0.2",
     "string-similarity": "^4.0.1",
-    "through": "^2.3.8",
-    "typescript": "~4.5.4"
+    "through": "^2.3.8"
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",
@@ -45,6 +44,10 @@
     "@types/readline-sync": "^1.4.3",
     "@types/string-similarity": "^3.0.0",
     "@types/through": "^0.0.30",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "typescript": "~4.5.5"
+  },
+  "peerDependencies": {
+    "typescript": ">=4.5"
   }
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -17,6 +17,10 @@ export async function revParse(name: string, cwd?: string) {
   return git(['rev-parse', name], cwd);
 }
 
+export function revParseSync(name: string = 'HEAD', cwd?: string) {
+  return gitSync(['rev-parse', name], cwd);
+}
+
 export async function commitCountBetween(from: string, to: string, cwd?: string) {
   return git(['rev-list', '--count', '^' + from, to], cwd);
 }
@@ -61,6 +65,11 @@ export async function getMergeBase(branch1: string, branch2: string, cwd?: strin
 
 export async function getTags(name: string = 'HEAD', cwd?: string) {
   const tags = await git(['tag', '--points-at', name], cwd);
+  return tags.split('\n').map(s => s.trim());
+}
+
+export function getTagsSync(name: string = 'HEAD', cwd?: string) {
+  const tags = gitSync(['tag', '--points-at', name], cwd);
   return tags.split('\n').map(s => s.trim());
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -17,10 +17,6 @@ export async function revParse(name: string, cwd?: string) {
   return git(['rev-parse', name], cwd);
 }
 
-export function revParseSync(name: string = 'HEAD', cwd?: string) {
-  return gitSync(['rev-parse', name], cwd);
-}
-
 export async function commitCountBetween(from: string, to: string, cwd?: string) {
   return git(['rev-list', '--count', '^' + from, to], cwd);
 }
@@ -65,11 +61,6 @@ export async function getMergeBase(branch1: string, branch2: string, cwd?: strin
 
 export async function getTags(name: string = 'HEAD', cwd?: string) {
   const tags = await git(['tag', '--points-at', name], cwd);
-  return tags.split('\n').map(s => s.trim());
-}
-
-export function getTagsSync(name: string = 'HEAD', cwd?: string) {
-  const tags = gitSync(['tag', '--points-at', name], cwd);
   return tags.split('\n').map(s => s.trim());
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export * as docker from './docker';
 export * as exec from './exec';
 export * as dotnet from './dotnet';
 export * as yarn from './yarn';
+export * as node from './node';
 export * as pnpm from './pnpm';
 export * as git from './git';
 export * as github from './github';

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,0 +1,13 @@
+import * as os from 'os';
+import * as childProcess from 'child_process';
+import * as path from 'path';
+import { projectPath } from './index';
+import * as exec from './exec';
+
+export async function runNode(args: string[] = [], options?: childProcess.SpawnOptions) {
+  const executable = os.platform() === 'win32' ? 'node.cmd' : 'node';
+  return await exec.spawn(path.join(projectPath, executable), args, {
+    cwd: projectPath,
+    ...(options ?? {}),
+  });
+}

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1,10 +1,11 @@
 import * as os from 'os';
 import * as childProcess from 'child_process';
 import * as path from 'path';
+import * as fs from 'fs';
 import { projectPath } from './index';
 import * as exec from './exec';
 import { currentVersion } from './version';
-import * as workspace from './workspace';
+import { runNode } from './node';
 
 export async function runScript(script: string, args: string[] = []) {
   return runYarn(['run', script, ...args]);
@@ -41,7 +42,36 @@ export function yarnInfo() {
 
 export async function runBin(bin: string, args: string[] = []) {
   const yarnBinOutput = (await runYarn(['bin', bin], { stdio: 'pipe' })).stdout.trim();
-  const executablePath = yarnBinOutput.split(os.EOL).pop()!;
+  /**
+   * Output can get bloated with echos from scripts and such. So we have no safe way of
+   * determine where in the list our actual output is.
+   *
+   * This will filter out all that noise and pick the real result from our command above
+   */
+  const executablePath = yarnBinOutput
+    // Windows can also return \n only in some environments
+    .split(/\n|\r\n/)
+    .filter(s => {
+      return fs.existsSync(s);
+    })
+    .pop()!;
+
+  if (executablePath === undefined || executablePath.length === 0) {
+    throw new Error(`Could not find the executable path for '${bin}'`);
+  }
+
+  /**
+   * Since introduction of Yarn PnP we can't rely on node_modules being present.
+   * yarn bin now returns the path of the js to be executed instead of the
+   * node_modules/.bin
+   */
+  if (executablePath.indexOf(path.join('node_modules', '.bin')) === -1) {
+    if (executablePath.endsWith('.js')) {
+      return await runNode([executablePath, ...args]);
+    }
+  }
+
+  // Yarn v1
   const executable = os.platform() === 'win32' ? executablePath + '.cmd' : executablePath;
   return await exec.spawn(executable, args, {
     cwd: projectPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,10 +801,10 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-typescript@~4.5.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+typescript@~4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
With yarns introduction to PnP (plug and play) yarn bin no longer returns the `/node_modules/.bin/SCRIPT` path any more. So we have to detect that and run node against that javascript file instead.