### PR TITLE
fix: add executable flag to garn bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/garn",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",
@@ -14,10 +14,11 @@
   },
   "scripts": {
     "build": "tsc --noEmit false",
+    "build:prod": "yarn clean && yarn build && chmod 755 dist/garn-bin.js",
     "watch": "yarn build --watch",
     "clean": "rimraf dist",
-    "prepack": "yarn clean && yarn build",
-    "prepublishOnly": "yarn clean && yarn build"
+    "prepack": "echo Running prepack && yarn run build:prod",
+    "prepublishOnly": "echo Running prepublishOnly && yarn run build:prod"
   },
   "dependencies": {
     "@octokit/rest": "^18.12.0",
@@ -33,7 +34,8 @@
     "readline-sync": "^1.4.10",
     "rimraf": "^3.0.2",
     "string-similarity": "^4.0.1",
-    "through": "^2.3.8"
+    "through": "^2.3.8",
+    "typescript": "~4.5.5"
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",


### PR DESCRIPTION
Since we have moved over to compiling the `garn-bin.ts` we must set the proper flag to `garn-bin.js`. It will work the first time you run yarn install. But if you update to a new version of garn it will lose the `+x` flag.