### PR TITLE
Fix spawn EINVAL for parallel tasks

### DIFF
--- a/src/run-in-parallel.ts
+++ b/src/run-in-parallel.ts
@@ -56,7 +56,7 @@ function executePrograms(programs: ParallelProgram[], isGarn: boolean = true) {
         }
 
         log.verbose(`Spawning '${program.program}${args.length === 0 ? '' : ' '}${args.join(' ')}'`);
-        const command = spawn(program.program, args, { stdio, ...(program.cwd ? { cwd: program.cwd } : {}) });
+        const command = spawn(program.program, args, { shell: true, stdio, ...(program.cwd ? { cwd: program.cwd } : {}) });
 
         const outThrough = through(
           function (this: any, data) {


### PR DESCRIPTION
When running tasks in parallel on Windows with node v22.x, an EINVAL error occurred. This is most probably a result of the changes in https://nodejs.org/en/blog/release/v20.12.2. 

Using shell : true makes it work again.