### PR TITLE
Handle GitHub auth error + add version flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@avensia-oss/garn",
-  "version": "1.0.4",
+  "version": "1.0.5-rc.2",
   "main": "dist/index.js",
   "repository": "https://github.com/avensia-oss/garn",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",

--- a/src/garn-bin.ts
+++ b/src/garn-bin.ts
@@ -38,6 +38,14 @@ if (isInstalledGlobally) {
     process.argv.splice(2, 0, '--' + buildsystemPathArgName, assumedBuildsystemPath);
   }
 
+  // Add --version support
+  if (process.argv.includes('--version') || process.argv.includes('-v')) {
+    const garnPackageJsonPath = path.join(__dirname, '..', 'package.json');
+    const garnPackageJson = JSON.parse(fs.readFileSync(garnPackageJsonPath).toString());
+    console.log(garnPackageJson.version);
+    process.exit(0);
+  }
+
   const argv = minimist(process.argv.slice(2));
 
   const buildsystemPath = argv[buildsystemPathArgName];
@@ -395,8 +403,8 @@ function printDiagnostics(allDiagnostics: typescript.Diagnostic[], buildsystemPa
         chalk.green(
           path.relative(projectPath, diagnostic.file.fileName) + '(' + line + 1 + ',' + character + 1 + '):',
         ) +
-        ' ' +
-        message,
+          ' ' +
+          message,
       );
       console.log();
     } else {
@@ -425,7 +433,7 @@ function buildCompilationManifest(dirInBuildCache: string, buildsystemPath: stri
   let files: string[] = [];
   try {
     files = fs.readdirSync(dirInBuildCache);
-  } catch (e) { }
+  } catch (e) {}
   for (const file of files) {
     const fullPath = path.join(dirInBuildCache, file);
     if (!fullPath.endsWith('.map') && !file.startsWith('.')) {

--- a/src/github-access.tsx
+++ b/src/github-access.tsx
@@ -34,6 +34,11 @@ export class GithubAccess {
     return await keytar.setPassword(GITHUB_ACCESS_TOKEN_ENV_NAME, GithubAccess.OAuthClientId, token);
   }
 
+  public static async clearAccessToken() {
+    const keytar = await import('keytar');
+    return await keytar.deletePassword(GITHUB_ACCESS_TOKEN_ENV_NAME, GithubAccess.OAuthClientId);
+  }
+
   public static async hasCredentials(): Promise<boolean> {
     return !!(await GithubAccess.getAccessToken());
   }


### PR DESCRIPTION
This PR adds handling when the github credentials expire. It will wipe the stored token and prompt the user to re-run the command and then log in like normally. 

This PR also adds `--version` and `-v` flags which will print the version that is set in garns package.json.